### PR TITLE
Add website assessment UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the foundation for an enterprise application that combi
 
 - `docs/PLAN.md` – Project plan and roadmap.
 - `src/cyberai/` – Python package for security and AI modules.
+- `src/ui.py` – Simple Streamlit interface for running assessments.
 - `tests/` – Unit tests for the codebase.
 - `requirements.txt` – Python dependencies.
 
@@ -18,6 +19,11 @@ This repository contains the foundation for an enterprise application that combi
 2. Run tests:
    ```bash
    pytest
+   ```
+
+3. Launch the web interface:
+   ```bash
+   streamlit run src/ui.py
    ```
 
 Use the plan in `docs/PLAN.md` to guide further development.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Base dependencies
 pandas
 scikit-learn
+streamlit

--- a/src/cyberai/__init__.py
+++ b/src/cyberai/__init__.py
@@ -1,0 +1,7 @@
+"""CyberAI package."""
+
+from . import ai
+from . import security
+from .assessment import assess_website
+
+__all__ = ["ai", "security", "assess_website"]

--- a/src/cyberai/assessment.py
+++ b/src/cyberai/assessment.py
@@ -1,0 +1,57 @@
+"""Basic website assessment utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+
+def assess_website(url: str, timeout: int = 5) -> Dict[str, object]:
+    """Run a simple security assessment against a website.
+
+    Parameters
+    ----------
+    url:
+        URL of the website to assess.
+    timeout:
+        Timeout in seconds for the HTTP request.
+
+    Returns
+    -------
+    dict
+        Dictionary containing the score and detected issues.
+    """
+    score = 0
+    checks = 0
+    issues: List[str] = []
+
+    if url.startswith("https://"):
+        score += 1
+    else:
+        issues.append("URL does not use HTTPS.")
+    checks += 1
+
+    try:
+        req = Request(url, headers={"User-Agent": "CyberAI"})
+        with urlopen(req, timeout=timeout) as resp:
+            headers = {k.lower(): v for k, v in resp.headers.items()}
+    except URLError as exc:  # pragma: no cover - network errors
+        issues.append(f"Error fetching URL: {exc}")
+        return {"url": url, "score": 0.0, "issues": issues}
+
+    security_headers = [
+        "content-security-policy",
+        "x-content-type-options",
+        "x-frame-options",
+        "strict-transport-security",
+    ]
+    for header in security_headers:
+        checks += 1
+        if header in headers:
+            score += 1
+        else:
+            issues.append(f"Missing header: {header}")
+
+    score_percent = round(100 * score / checks, 2) if checks else 0.0
+    return {"url": url, "score": score_percent, "issues": issues}

--- a/src/ui.py
+++ b/src/ui.py
@@ -1,0 +1,13 @@
+import streamlit as st
+from cyberai.assessment import assess_website
+
+st.title("Cyber Assessment Tool")
+url = st.text_input("Website URL")
+if st.button("Run Assessment") and url:
+    with st.spinner("Scanning..."):
+        result = assess_website(url)
+    st.write(f"**Score:** {result['score']}")
+    if result['issues']:
+        st.subheader("Issues")
+        for issue in result['issues']:
+            st.write(f"- {issue}")

--- a/tests/test_assessment.py
+++ b/tests/test_assessment.py
@@ -1,0 +1,34 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from cyberai.assessment import assess_website
+
+
+def test_assess_website_https_and_headers():
+    mock_resp = MagicMock()
+    mock_resp.headers = {
+        'Content-Security-Policy': 'default-src self',
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'DENY',
+        'Strict-Transport-Security': 'max-age=31536000',
+    }
+    mock_context = MagicMock()
+    mock_context.__enter__.return_value.headers = mock_resp.headers
+    with patch('cyberai.assessment.urlopen', return_value=mock_context):
+        result = assess_website('https://example.com')
+    assert result['score'] == 100.0
+    assert result['issues'] == []
+
+
+def test_assess_website_missing_headers_and_http():
+    mock_resp = MagicMock()
+    mock_resp.headers = {}
+    mock_context = MagicMock()
+    mock_context.__enter__.return_value.headers = mock_resp.headers
+    with patch('cyberai.assessment.urlopen', return_value=mock_context):
+        result = assess_website('http://example.com')
+    assert result['score'] < 100.0
+    assert 'URL does not use HTTPS.' in result['issues']


### PR DESCRIPTION
## Summary
- create `assessment` module with basic website assessment logic
- expose `assess_website` from package
- add minimal Streamlit UI
- document new UI in README
- add unit tests for `assess_website`
- update dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e9b786108328bbbc99f171300420